### PR TITLE
Remove extraneous dot from class name

### DIFF
--- a/modules/ext.details/ext.details.js
+++ b/modules/ext.details/ext.details.js
@@ -72,7 +72,7 @@ function makeCollapsible( el ) {
 	}
 
 	// Replace placeholder with a real toggle
-	if ( toggle.hasClass( '.mw-collapsible-toggle-placeholder' ) ) {
+	if ( toggle.hasClass( 'mw-collapsible-toggle-placeholder' ) ) {
 		const newToggle = makeToggle( options );
 		toggle.replaceWith( newToggle );
 		toggle = newToggle;


### PR DESCRIPTION
`hasClass()` doesn't need any dot.